### PR TITLE
Api add bulk edit permission

### DIFF
--- a/includes/class-iahsp-functionality.php
+++ b/includes/class-iahsp-functionality.php
@@ -187,6 +187,8 @@ class Iahsp_Functionality {
     $this->loader->add_action( 'after_setup_theme', $plugin_public, 'add_woocommerce_support' );
     $this->loader->add_action( 'login_enqueue_scripts', $plugin_public, 'custom_login_page_logo' );
     $this->loader->add_filter( 'woocommerce_account_menu_items', $plugin_public, 'remove_items_woo_myaccount_nav', 99 );
+    //$this->loader->add_filter( 'woocommerce_rest_check_permissions', $plugin_public, 'allow_woo_api_bulk_edit', 10, 4  );
+    $this->loader->add_action( 'rest_api_init', $plugin_public, 'register_inventory_get_levels');
 
     // SHOTCODES HERE
     add_shortcode( 'iahsp_user_registration', array($plugin_public, 'custom_registration_shortcode') );

--- a/includes/class-iahsp-functionality.php
+++ b/includes/class-iahsp-functionality.php
@@ -187,6 +187,7 @@ class Iahsp_Functionality {
     $this->loader->add_action( 'after_setup_theme', $plugin_public, 'add_woocommerce_support' );
     $this->loader->add_action( 'login_enqueue_scripts', $plugin_public, 'custom_login_page_logo' );
     $this->loader->add_filter( 'woocommerce_account_menu_items', $plugin_public, 'remove_items_woo_myaccount_nav', 99 );
+    $this->loader->add_filter( 'woocommerce_rest_check_permissions', $plugin_public, 'vendor_allow_bulk_api_edit', 99, 4 );
 
     // SHOTCODES HERE
     add_shortcode( 'iahsp_user_registration', array($plugin_public, 'custom_registration_shortcode') );

--- a/includes/class-iahsp-functionality.php
+++ b/includes/class-iahsp-functionality.php
@@ -187,7 +187,7 @@ class Iahsp_Functionality {
     $this->loader->add_action( 'after_setup_theme', $plugin_public, 'add_woocommerce_support' );
     $this->loader->add_action( 'login_enqueue_scripts', $plugin_public, 'custom_login_page_logo' );
     $this->loader->add_filter( 'woocommerce_account_menu_items', $plugin_public, 'remove_items_woo_myaccount_nav', 99 );
-    //$this->loader->add_filter( 'woocommerce_rest_check_permissions', $plugin_public, 'allow_woo_api_bulk_edit', 10, 4  );
+    $this->loader->add_action( 'rest_api_init', $plugin_public, 'register_inventory_update_bulk');
     $this->loader->add_action( 'rest_api_init', $plugin_public, 'register_inventory_get_levels');
 
     // SHOTCODES HERE

--- a/public/class-iahsp-functionality-public.php
+++ b/public/class-iahsp-functionality-public.php
@@ -543,7 +543,10 @@ class Iahsp_Functionality_Public {
         $productQuantity = intval($item['stock_quantity']);
 
         $productObj = wc_get_product( $productID );
+        //$productObj  = new WC_Product($productID);
+        $productObj->set_manage_stock(true); //just in case manage stock is turned off
         $productObj->set_stock_quantity($productQuantity);
+        $productObj->save(); //without save, the change doesn't happen :o
 
         error_log("update: {$productID} with this much: {$productQuantity}");
       } //foreach

--- a/public/class-iahsp-functionality-public.php
+++ b/public/class-iahsp-functionality-public.php
@@ -555,7 +555,7 @@ class Iahsp_Functionality_Public {
         //$productObj  = new WC_Product($productID);
         //$authorCheck = $productObj->get_id();
         $authorCheckID = get_post_field('post_author', $productID);
-        error_log("current author is: " . $authorCheck);
+        //error_log("current author is: " . $authorCheck);
 
         if ($currentUID == $authorCheckID) {
           $productObj = wc_get_product( $productID );

--- a/public/class-iahsp-functionality-public.php
+++ b/public/class-iahsp-functionality-public.php
@@ -504,4 +504,63 @@ class Iahsp_Functionality_Public {
     return $this->resellerCertificate->upload_form_shortcode();
   } //custom_registration_shortcode
 
+  public function allow_woo_api_bulk_edit($permission, $context, $object_id, $post_type) {
+    error_log("permission: {$permission}, context: {$context}, object_id: {$object_id}, post_type: {$post_type}");
+    if ($context == "batch" && $post_type == "product") {
+      return 1;
+    } else {
+      return $permission;
+    }
+  }
+
+  //public function register_inventory_update_bulk() {
+    ////
+  //}
+
+  public function register_inventory_get_levels() {
+    register_rest_route( 'wc/v3', 'savvy-inventory', array(
+      'methods' => 'GET',
+      'callback' => array($this, 'inventory_get_levels')
+    ));
+  }
+
+  //public function inventory_update_bulk() {
+    ////
+  //}
+
+  public function inventory_get_levels(WP_REST_Request $request) {
+    //error_log(print_r($payload, true));
+    $allParams = $request->get_params();
+    error_log(print_r($allParams, true));
+
+    // if they got this far, then their auth already worked. (thanks wordpress!)
+    $currentUser = wp_get_current_user();
+    $currentUID = $currentUser->ID;
+
+    $thisVendorsProducts = wc_get_products( array(
+      'status'    => 'publish',
+      'limit'     => -1,
+      'author'    => $currentUID
+    ));
+
+    $productsCollection = [];
+
+    foreach ($thisVendorsProducts as $singleProduct) {
+      $product = [
+        "sku" => $singleProduct->sku,
+        "id" => $singleProduct->id,
+        "name" => $singleProduct->get_title()
+      ];
+
+      $productsCollection[] = $product;
+      error_log(print_r($product, true));
+    }
+
+
+    //header('Content-type: application/json');
+    //return json_encode($productsCollection);
+    return $productsCollection;
+  }
+
+
 }

--- a/public/class-iahsp-functionality-public.php
+++ b/public/class-iahsp-functionality-public.php
@@ -599,29 +599,37 @@ class Iahsp_Functionality_Public {
     $currentUser = wp_get_current_user();
     $currentUID = $currentUser->ID;
 
-    $thisVendorsProducts = wc_get_products( array(
-      'status'    => 'publish',
-      'limit'     => -1,
-      'author'    => $currentUID
-    ));
+    if ($currentUID >= 1) {
+      //error_log("current user: {$currentUID}");
+      $thisVendorsProducts = wc_get_products( array(
+        'status'    => 'publish',
+        'limit'     => -1,
+        'author'    => $currentUID
+      ));
 
-    $productsCollection = [];
+      $productsCollection = [];
 
-    foreach ($thisVendorsProducts as $singleProduct) {
-      $product = [
-        "sku" => $singleProduct->get_sku(),
-        "id" => $singleProduct->get_id(),
-        "stock_quantity" => $singleProduct->get_stock_quantity(),
-        "name" => $singleProduct->get_title()
+      foreach ($thisVendorsProducts as $singleProduct) {
+        $product = [
+          "sku" => $singleProduct->get_sku(),
+          "id" => $singleProduct->get_id(),
+          "stock_quantity" => $singleProduct->get_stock_quantity(),
+          "name" => $singleProduct->get_title()
+        ];
+
+        $productsCollection[] = $product;
+        //error_log(print_r($product, true));
+      }
+
+
+      // no need to send json header, or json encode, it's handled by the built in stuffs
+      return $productsCollection;
+    } else {
+      return [
+        "error" => "access denied"
       ];
-
-      $productsCollection[] = $product;
-      //error_log(print_r($product, true));
     }
 
-
-    // no need to send json header, or json encode, it's handled by the built in stuffs
-    return $productsCollection;
   }
 
 

--- a/public/class-iahsp-functionality-public.php
+++ b/public/class-iahsp-functionality-public.php
@@ -528,6 +528,12 @@ class Iahsp_Functionality_Public {
     $currentUser = wp_get_current_user();
     $currentUID = $currentUser->ID;
 
+    if ($currentUID == 0) {
+      return [
+        "error" => "access denied"
+      ];
+    }
+
     $payload = $request->get_params();
 
     //error_log(print_r($payload, true));
@@ -543,6 +549,7 @@ class Iahsp_Functionality_Public {
 
         // lets get the product ID, either from the SKU, or already specified in the body
         $productID = (!$item['id']) ? wc_get_product_id_by_sku( $item['sku'] ) : $item['id'];
+        $initialGivenKey = ($item['id']) ? $item['id'] : $item['sku'];
         $productQuantity = intval($item['stock_quantity']);
 
         //$productObj  = new WC_Product($productID);
@@ -559,7 +566,7 @@ class Iahsp_Functionality_Public {
           $prodIDsHolder[] = $productID;
         } else {
           //current user does not own product they are trying to edit
-          $failedProdIDsHolder[] = $productID;
+          $failedProdIDsHolder[] = $initialGivenKey;
         }
 
         //error_log("update: {$productID} with this much: {$productQuantity}");
@@ -571,10 +578,9 @@ class Iahsp_Functionality_Public {
     } //endif
 
     //after successful inserts, lets grab inventory levels and return 
-    foreach ($failedProdIDsHolder as $pid) {
+    foreach ($failedProdIDsHolder as $pidOrSKU) {
       $product = [
-        "id" => $pid,
-        "error" => "unauthorized to edit product."
+        "error" => "Product '{$pidOrSKU}' is not found."
       ];
       $productsCollection[] = $product;
     }

--- a/public/class-iahsp-functionality-public.php
+++ b/public/class-iahsp-functionality-public.php
@@ -504,4 +504,31 @@ class Iahsp_Functionality_Public {
     return $this->resellerCertificate->upload_form_shortcode();
   } //custom_registration_shortcode
 
+  public function vendor_allow_bulk_api_edit($permission, $context, $object_id, $post_type) {
+    error_log("permission: {$permission} / context: {$context} / object_id: {$object_id} / post_type: {$post_type}");
+    if ($context == 'batch') {
+      $request = new WP_REST_Request;
+      $restBody = $request->get_body();
+      error_log("rest body: {$restBody}");
+    }
+    error_log('-------');
+    if ($post_type == 'product') {
+      // Get current user
+      $user = wp_get_current_user();
+
+      // Check if user has vendor role
+      if ( in_array( 'seller', (array) $user->roles ) ) {
+        //The user has the vendor role of "seller" role
+
+        //check if author of product matches current user
+
+        //everything checks out, return 
+        return $permission;
+      } else {
+        return 0;
+      }
+    }
+
+  
+  }
 }


### PR DESCRIPTION
This is new functionality that leverages the woo-commerce API key generation, and then adds a new woo commerce end point to the API, allowing a vendor to bulk update their inventory, for only the items that belong to them.  They can also use this to check inventory levels.